### PR TITLE
Correct crash on adding waypoint on iOS7

### DIFF
--- a/iGCS/UserInterface/ViewControllers/WaypointMapBaseController.h
+++ b/iGCS/UserInterface/ViewControllers/WaypointMapBaseController.h
@@ -14,6 +14,7 @@
 
 #define WAYPOINT_TOUCH_TARGET_SIZE 36
 
+#define MAP_MINIMUM_PAD       100
 #define MAP_MINIMUM_ARC       0.0010 // ~100m
 #define MAP_REGION_PAD_FACTOR 1.10
 

--- a/iGCS/UserInterface/ViewControllers/WaypointMapBaseController.m
+++ b/iGCS/UserInterface/ViewControllers/WaypointMapBaseController.m
@@ -112,11 +112,17 @@
     [map addOverlay:waypointRoutePolyline];
     
     // Set the map extents
-    MKCoordinateRegion region = MKCoordinateRegionForMapRect([waypointRoutePolyline boundingMapRect]);
-    if ([waypointRoutePolyline pointCount] >= 1) {
+    MKMapRect bounds = [waypointRoutePolyline boundingMapRect];
+    if (!MKMapRectIsNull(bounds)) {
+        // Extend the bounding rect of the polyline slightly
+        MKCoordinateRegion region = MKCoordinateRegionForMapRect(bounds);
         region.span.latitudeDelta  = MIN(MAX(region.span.latitudeDelta  * MAP_REGION_PAD_FACTOR, MAP_MINIMUM_ARC),  90);
         region.span.longitudeDelta = MIN(MAX(region.span.longitudeDelta * MAP_REGION_PAD_FACTOR, MAP_MINIMUM_ARC), 180);
         [map setRegion:region animated:YES];
+    } else if ([waypointRoutePolyline pointCount] == 1) {
+        // Fallback to a padded box centered on the single waypoint
+        CLLocationCoordinate2D coord = MKCoordinateForMapPoint([waypointRoutePolyline points][0]);
+        [map setRegion:MKCoordinateRegionMakeWithDistance(coord, MAP_MINIMUM_PAD, MAP_MINIMUM_PAD) animated:YES];
     }
     [map setNeedsDisplay];
     


### PR DESCRIPTION
- appears the behaviour of the bounding rect (and centre coordinate)
  of a polyline with a single point changed in iOS7
