### PR TITLE
Update ssh submodule URL for core-plot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git://github.com/andymoe/kxmovie.git
 [submodule "submodules/core-plot"]
 	path = submodules/core-plot
-	url = git@github.com:fightingwalrus/core-plot.git
+	url = git://github.com:fightingwalrus/core-plot.git


### PR DESCRIPTION
I messed up and used a RW ssh git url for
the core-plot submodule. This prevents the
submodules from being pulled down by people
with RO access to our core-plot fork on
github.
