### PR TITLE
Map View: Update RATE_CHAN2 request rate to 5Hz

### DIFF
--- a/iGCS/UserInterface/Views/GaugeViewCommon.h
+++ b/iGCS/UserInterface/Views/GaugeViewCommon.h
@@ -10,7 +10,7 @@
 #define iGCS_GaugeViewCommon_h
 
 // Default data rates
-#define RATE_CHAN2        1  // SYS_STATUS, GPS_STATUS, WAYPOINT_CURRENT, GPS_RAW
+#define RATE_CHAN2        5  // SYS_STATUS, GPS_STATUS, WAYPOINT_CURRENT, GPS_RAW
 #define RATE_GPS_POS_INT  5
 #define RATE_ATTITUDE    10
 #define RATE_VFR_HUD      5


### PR DESCRIPTION
- Improves position of craft on map view.
  There are still very occasional jumps but
  that is possibly due to lot of work being
  done on main thread elsewhere in the app.
