### PR TITLE
FWR firmware uploader: bump firmware version string

### DIFF
--- a/iGCS/GCSFirmwareUtils.m
+++ b/iGCS/GCSFirmwareUtils.m
@@ -10,7 +10,7 @@
 
 NSString * const GCSFirmwareUtilsFwrFirmwareNeedsUpdated = @"com.fightingwalrus.firmwareutils.fwrfirmware.needsupdate";
 NSString * const GCSFwrFirmwareFileName = @"walrus.bin";
-NSString * const GCSFirmwareVersionInBundle = @"0.0.5";
+NSString * const GCSFirmwareVersionInBundle = @"0.1.0";
 
 static BOOL _awaitingPostUpgradeDisconnect;
 


### PR DESCRIPTION
- smallest PR ever.
- new firmware bin has been checked into our fwrfirmwarebins repo.
- in future I'll get version number from bin file name.
