### PR TITLE
CRASHING BUG - CommInterface: use NSAssert instead of assert

### DIFF
--- a/iGCS/Comm/CommInterface.m
+++ b/iGCS/Comm/CommInterface.m
@@ -23,10 +23,11 @@
 -(void)produceData:(const uint8_t*)bytes length:(int)length {
 
     // ConnectionPool must be assigned
+    NSAssert(self.connectionPool, @"connectionPool can not be nil.");
     if (!self.connectionPool) {
         [Logger error:@"Error: Tried to call produceData, but no connectionPool was set."];
+        return;
     }
-    assert(self.connectionPool);
 
     [self.connectionPool interface:self producedBytes:bytes length:length];
 }


### PR DESCRIPTION
- NSAssert won't crash when compiled in release mode
- I think this should keep the app from crashing in release mode
  when we try to send data and there is no accessory connected.
- Does not address any issues around UX when user tries to
  take action that requires a connection or radio accessory.
