### PR TITLE
Radio Config: always try to start telemetry on cancel

### DIFF
--- a/iGCS/UserInterface/ViewControllers/RadioSettingsViewController.m
+++ b/iGCS/UserInterface/ViewControllers/RadioSettingsViewController.m
@@ -220,7 +220,7 @@ static void *SVKvoContext = &SVKvoContext;
 #pragma mark - UINavigationBar Button handlers
 
 - (void)cancelChanges:(id)sender {
-    [self exitConfigMode];
+    [[CommController sharedInstance] startTelemetryMode];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 


### PR DESCRIPTION
- Calling the startTelemetryMode when canceling radio
  config restarts the device by tearing down EAAccessory
  connection and keeps the device in a better state so that
  subsequent attempts at radio configuration have a better
  chance of working properly.
