### PR TITLE
Comm: possible fix for intermittent crash

### DIFF
--- a/iGCS/Comm/Interfaces/iGCS/iGCSMavLinkInterface.m
+++ b/iGCS/Comm/Interfaces/iGCS/iGCSMavLinkInterface.m
@@ -60,6 +60,10 @@ MavLinkRetryingRequestHandler* retryRequestHandler;
     return self;
 }
 
+-(void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 -(void)close {
     DDLogDebug(@"iGCSMavLinkInterface: close is a noop");
 }


### PR DESCRIPTION
- Unmatches NSNotifcations registrations and
  timing possibly causing missing selector crash
  when you cancel the radio config and teardown/start
  telemetry
