### PR TITLE
Update supported firmware to 1.0.6

### DIFF
--- a/iGCS/Comm/CommController.m
+++ b/iGCS/Comm/CommController.m
@@ -9,6 +9,7 @@
 #import "CommController.h"
 #import "Logger.h"
 #import "SoundUtils.h"
+#import "GCSFirmwareUtils.h"
 
 NSString * const GCSCommControllerFightingWalrusRadioNotConnected = @"com.fightingwalrus.commcontroller.fwr.notconnected";
 
@@ -214,7 +215,7 @@ NSString * const GCSCommControllerFightingWalrusRadioNotConnected = @"com.fighti
     for (EAAccessory *accessory in accessories) {
         DDLogDebug(@"%@",accessory.manufacturer);
 
-        if ([accessory.manufacturer isEqualToString:@"Fighting Walrus LLC"]) {
+        if ([GCSFirmwareUtils isAccessorySupportedWithAccessory:accessory]) {
             gcsAccessory = GCSAccessoryFightingWalrusRadio;
             break;
         }

--- a/iGCS/Comm/Interfaces/FightingWalrus2/FightingWalrusInterface.m
+++ b/iGCS/Comm/Interfaces/FightingWalrus2/FightingWalrusInterface.m
@@ -53,7 +53,7 @@ NSString * const GCSProtocolStringUpdate = @"com.fightingwalrus.update";
         DDLogInfo(@"accessory count: %lu", (unsigned long)[_accessoryList count]);
         if ([self.accessoryList count]) {
             for(EAAccessory *currentAccessory in _accessoryList) {
-                BOOL comparison = [currentAccessory.manufacturer isEqualToString:@"Fighting Walrus LLC"];
+                BOOL comparison = [GCSFirmwareUtils isAccessorySupportedWithAccessory:currentAccessory];
                 if(comparison){
                     self.selectedAccessory = currentAccessory;
                     DDLogDebug(@"Manufacturer of our device is %@",_selectedAccessory.manufacturer);

--- a/iGCS/GCSFirmwareUtils.h
+++ b/iGCS/GCSFirmwareUtils.h
@@ -7,13 +7,16 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <ExternalAccessory/ExternalAccessory.h>
 
 @interface GCSFirmwareUtils : NSObject
 +(BOOL)isFirmwareUpdateNeededWithFirmwareRevision:(NSString *) firmwareRevision;
 +(void)notifyFwrFirmwareUpateNeeded;
-+(void)setAwaitingPostUpgradeDisconnect:(BOOL)value;
++(void)setAwaitingPostUpgradeDisconnect:(BOOL) value;
++(BOOL)isAccessorySupportedWithAccessory:(EAAccessory *)accessory;
 @end
 
 extern NSString * const GCSFirmwareUtilsFwrFirmwareNeedsUpdated;
 extern NSString * const GCSCurrentFirmwareFileName;
 extern NSString * const GCSFirmwareVersionInBundle;
+extern NSString * const GCSCompanyName;

--- a/iGCS/GCSFirmwareUtils.m
+++ b/iGCS/GCSFirmwareUtils.m
@@ -10,7 +10,8 @@
 
 NSString * const GCSFirmwareUtilsFwrFirmwareNeedsUpdated = @"com.fightingwalrus.firmwareutils.fwrfirmware.needsupdate";
 NSString * const GCSFwrFirmwareFileName = @"walrus.bin";
-NSString * const GCSFirmwareVersionInBundle = @"0.1.0";
+NSString * const GCSFirmwareVersionInBundle = @"1.0.6";
+NSString * const GCSCompanyName = @"Fighting Walrus, LLC";
 
 static BOOL _awaitingPostUpgradeDisconnect;
 
@@ -31,6 +32,18 @@ static BOOL _awaitingPostUpgradeDisconnect;
 
 +(void)setAwaitingPostUpgradeDisconnect:(BOOL)value {
     _awaitingPostUpgradeDisconnect = value;
+}
+
++(BOOL)isAccessorySupportedWithAccessory:(EAAccessory *)accessory {
+    NSCharacterSet *nonAlphaCharacterSet = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
+
+    NSString *accessoryManufactuer = [[[accessory.manufacturer componentsSeparatedByCharactersInSet:nonAlphaCharacterSet]
+                                      componentsJoinedByString:@""] lowercaseString];
+
+    NSString *companyName = [[[GCSCompanyName componentsSeparatedByCharactersInSet:nonAlphaCharacterSet]
+                             componentsJoinedByString:@""] lowercaseString];
+
+    return [accessoryManufactuer isEqualToString:companyName];
 }
 
 @end


### PR DESCRIPTION
- Bump firmware support to v1.0.6
- Add isAccessorySupportedWithAccessory: method
  that ignores non-whitespace and special characters
  since some older firmware has a comma in company
  name. This will also allow us to update the logic to use
  a whitelist of device SKUs etc in future.
  Not really sure if this method belongs in the GCSFirmwareUtils file. Thoughts?
