### PR TITLE
UI: Don't use storyboard as launch screen

### DIFF
--- a/iGCS/iGCS-Info.plist
+++ b/iGCS/iGCS-Info.plist
@@ -50,8 +50,6 @@
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>In order to display your location on the iGCS map</string>
-	<key>UILaunchStoryboardName</key>
-	<string>MainStoryboard</string>
 	<key>UIMainStoryboardFile</key>
 	<string>MainStoryboard</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
- Since we hide the comm and debug tab relying on the storyboard for
  a launch screen in iOS 8 is problematic. This chance makes iOS 8 to
  fall back to use the black images provided to the project as the launch
  screen. 
