### PR TITLE
Back out accidential 10m value; Set both defaults to 25m

### DIFF
--- a/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
+++ b/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
@@ -73,7 +73,7 @@ static const NSUInteger AIRCRAFT_ICON_SIZE = 62;
     self.currentGuidedAnnotation   = nil;
     self.requestedGuidedAnnotation = nil;
     
-    self.gotoAltitude = 50;
+    self.gotoAltitude = 25;
     
     self.showProposedFollowPos = NO;
     self.lastFollowMeUpdate = [NSDate date];

--- a/iGCS/UserInterface/ViewControllers/WaypointsViewController.h
+++ b/iGCS/UserInterface/ViewControllers/WaypointsViewController.h
@@ -10,7 +10,7 @@
 #import "WaypointsHolder.h"
 
 #define TABLE_MAP_SLIDE_AMOUNT 100
-#define WAYPOINT_DEFAULT_ALTITUDE 10
+#define WAYPOINT_DEFAULT_ALTITUDE 25
 
 @protocol MissionItemEditingDelegate
 - (WaypointsHolder*) cloneMission;


### PR DESCRIPTION
- We had accidentally merged in a default value of 10m when testing ar.drone... this reverses that and sets a better default for the quads (matches existing defaults in other software for quads)
- Opened ticket to make these defaults aircraft dependent.
