### PR TITLE
README: Remove reference to Redpark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-![alt tag](https://raw.github.com/fightingwalrus/iGCS/master/iGCS/Icons/Icon-50.png) iGCS
+![alt tag](https://raw.github.com/fightingwalrus/iGCS/master/iGCS/Icons/Icon-50.png) iDroneCtrl
 ====
 
-iGCS is a UAV Ground Control Station for iPad and iPhone. 
+iDroneCtrl (formally iGCS) is a UAV Ground Control Station for iPad and iPhone. 
 
-It is intended for use with UAVs conforming to the MAVLink protocol, such as the [ArduPilot Mega](http://dev.ardupilot.com), the Pixhawk as used in the 3DR Iris, and the AR.Drone 2.0 (with Flight Recorder).
+It is intended for use with UAVs conforming to the MAVLink protocol, such as the [ArduPilot Mega](http://dev.ardupilot.com), the Pixhawk as used in the 3DR IRIS, IRIS+ and the AR.Drone 2.0 (with Flight Recorder).
 
-It requires the iDroneLink available at www.fightingwalrus.com or a RedPark Serial cable for connecting to serial device such as an XBee or XTend radio for development purposes.
+It requires the "Made for iPhone" and "Made for iPad" iDroneLink available for sale at www.fightingwalrus.com
+
+You can download iDroneCtrl from the App Store here:
+
+[iDroneCtrl - Fighting Walrus](https://itunes.apple.com/us/app/idronectrl/id948077202?mt=8&uo=4)
 
 For further details, see:
+
 - http://www.fightingwalrus.com
 - http://diydrones.com/profiles/blogs/ipad-ground-control-station
 - http://www.youtube.com/watch?v=S1YOwLGsUrs
@@ -28,9 +33,9 @@ Building
 Updating the MAVLink library
 ============================
 
-The MAVLink header only C lib used in iGCS is generated from a fork of the master branch of the [MAVLink](https://github.com/mavlink/mavlink) project hosted on github.
+The MAVLink header only C lib used in iDroneCtrl is generated from a fork of the master branch of the [MAVLink](https://github.com/mavlink/mavlink) project hosted on github.
 
-Fighting Walrus maintains a [fork](https://github.com/fightingwalrus/mavlink) of the MAVLink repository that tracks upstream. Please use the following steps in order to update the MAVLink lib used in iGCS.
+Fighting Walrus maintains a [fork](https://github.com/fightingwalrus/mavlink) of the MAVLink repository that tracks upstream. Please use the following steps in order to update the MAVLink lib used in iDroneCtrl.
 
 1. Ensure the master branch of https://github.com/fightingwalrus/mavlink has all upstream changes from master merged in to master our master branch.
 2. Clone https://github.com/fightingwalrus/mavlink
@@ -59,7 +64,7 @@ Commit and push your changes and open a pull request for review and further HIL 
 
 License
 =======
-All iGCS code is licensed under the [MIT License](http://www.opensource.org/licenses/mit-license.php).
+All iDroneLink (formally iGCS) code is licensed under the [MIT License](http://www.opensource.org/licenses/mit-license.php).
 For other code and assets, see ATTRIBUTION.md.
 
 The MIT License (MIT)


### PR DESCRIPTION
- Update name to iDroneCtrl
- Add App Store download link
