### PR TITLE
Eliminate zooming code.  

### DIFF
--- a/iGCS/UserInterface/ViewControllers/WaypointMapBaseController.m
+++ b/iGCS/UserInterface/ViewControllers/WaypointMapBaseController.m
@@ -175,9 +175,6 @@
     
     // Set the map extents
     NSUInteger offset = isHomeWPInitialised ? 0 : 1;
-    if (offset < numWaypoints) {
-        [self zoomInOnCoordinates:coords+offset withLength:numWaypoints-offset]; // don't include HOME/0 in zoom area when not initialised
-    }
     [self.mapView setNeedsDisplay];
     
     free(coords);


### PR DESCRIPTION
The user will zoom the map to what they want to see, there is no need to zoom for them.