### PR TITLE
Telemetry: wrap heartbeat struct in NSObject; handle speech manager edge cases

### DIFF
--- a/iGCS Tests/MavUtilityTests.m
+++ b/iGCS Tests/MavUtilityTests.m
@@ -31,27 +31,34 @@
 - (void)testMavCustomModeToString
 {
     mavlink_heartbeat_t heartbeat;
-    
+    GCSHeartbeat *aHeartbeat;
+
     heartbeat.autopilot = MAV_AUTOPILOT_ARDUPILOTMEGA;
     heartbeat.type      = MAV_TYPE_FIXED_WING;
     heartbeat.custom_mode = APMPlaneFlyByWireC;
-    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:heartbeat], @"FBW_C", @"Incorrect fixed wing mode");
+
+    aHeartbeat = [GCSHeartbeat heartbeatFromMavlinkHeartbeat:heartbeat];
+    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:aHeartbeat], @"FBW_C", @"Incorrect fixed wing mode");
     
     heartbeat.autopilot = MAV_AUTOPILOT_ARDUPILOTMEGA;
     heartbeat.type      = MAV_TYPE_QUADROTOR;
     heartbeat.custom_mode = APMCopterCircle;
-    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:heartbeat], @"Circle", @"Incorrect quadcopter mode");
-    
+
+    aHeartbeat = [GCSHeartbeat heartbeatFromMavlinkHeartbeat:heartbeat];
+    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:aHeartbeat], @"Circle", @"Incorrect quadcopter mode");
+
     heartbeat.autopilot = MAV_AUTOPILOT_ARDUPILOTMEGA;
     heartbeat.type      = MAV_TYPE_GENERIC;
     heartbeat.custom_mode = APMPlaneFlyByWireC;
-    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:heartbeat], @"CUSTOM_MODE (7)", @"Incorrect generic type mode");
+
+    aHeartbeat = [GCSHeartbeat heartbeatFromMavlinkHeartbeat:heartbeat];
+    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:aHeartbeat], @"CUSTOM_MODE (7)", @"Incorrect generic type mode");
     
     heartbeat.autopilot = MAV_AUTOPILOT_GENERIC;
     heartbeat.type      = MAV_TYPE_FIXED_WING;
     heartbeat.custom_mode = APMPlaneFlyByWireC;
-    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:heartbeat], @"CUSTOM_MODE (7)", @"Incorrect generic autopilot mode");
+    aHeartbeat = [GCSHeartbeat heartbeatFromMavlinkHeartbeat:heartbeat];
+    XCTAssertEqualObjects([MavLinkUtility mavCustomModeToString:aHeartbeat], @"CUSTOM_MODE (7)", @"Incorrect generic autopilot mode");
 }
 
 @end
-

--- a/iGCS.xcodeproj/project.pbxproj
+++ b/iGCS.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		18069FD21836F7C70068E7A5 /* iGCSMavLinkInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = 18069FB71836F7C70068E7A5 /* iGCSMavLinkInterface.m */; };
 		18069FD41836F7C70068E7A5 /* iGCSRadioConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 18069FB91836F7C70068E7A5 /* iGCSRadioConfig.m */; };
 		18069FD81836F7C70068E7A5 /* RNBluetoothInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = 18069FBF1836F7C70068E7A5 /* RNBluetoothInterface.m */; };
+		181104A81A98282D00D1B58D /* GCSHeartbeat.m in Sources */ = {isa = PBXBuildFile; fileRef = 181104A71A98282D00D1B58D /* GCSHeartbeat.m */; };
+		181104A91A98282D00D1B58D /* GCSHeartbeat.m in Sources */ = {isa = PBXBuildFile; fileRef = 181104A71A98282D00D1B58D /* GCSHeartbeat.m */; };
 		1830D07217D1651400F77F7E /* DateTimeUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1830D07117D1651400F77F7E /* DateTimeUtils.m */; };
 		1842F8CA1892D2F80050F680 /* Icon-29.png in Resources */ = {isa = PBXBuildFile; fileRef = 1842F8C41892D2F80050F680 /* Icon-29.png */; };
 		1842F8CC1892D2F80050F680 /* Icon-40.png in Resources */ = {isa = PBXBuildFile; fileRef = 1842F8C51892D2F80050F680 /* Icon-40.png */; };
@@ -470,6 +472,8 @@
 		18069FBC1836F7C70068E7A5 /* RedparkSerialCable.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RedparkSerialCable.m; sourceTree = "<group>"; };
 		18069FBE1836F7C70068E7A5 /* RNBluetoothInterface.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBluetoothInterface.h; sourceTree = "<group>"; };
 		18069FBF1836F7C70068E7A5 /* RNBluetoothInterface.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBluetoothInterface.m; sourceTree = "<group>"; };
+		181104A61A98282D00D1B58D /* GCSHeartbeat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCSHeartbeat.h; sourceTree = "<group>"; };
+		181104A71A98282D00D1B58D /* GCSHeartbeat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCSHeartbeat.m; sourceTree = "<group>"; };
 		1830D07017D1651400F77F7E /* DateTimeUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateTimeUtils.h; sourceTree = "<group>"; };
 		1830D07117D1651400F77F7E /* DateTimeUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DateTimeUtils.m; sourceTree = "<group>"; };
 		1842F8C41892D2F80050F680 /* Icon-29.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-29.png"; sourceTree = "<group>"; };
@@ -1188,9 +1192,19 @@
 			path = RovingNetworks;
 			sourceTree = "<group>";
 		};
+		181104A51A98282D00D1B58D /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				181104A61A98282D00D1B58D /* GCSHeartbeat.h */,
+				181104A71A98282D00D1B58D /* GCSHeartbeat.m */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
 		1851D848191ADFD900ED5C87 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				181104A51A98282D00D1B58D /* Telemetry */,
 				18C91D271A71F752009400C3 /* Craft */,
 				1851D84D191AE00400ED5C87 /* GCSRadioSettings.h */,
 				1851D84E191AE00400ED5C87 /* GCSRadioSettings.m */,
@@ -2426,6 +2440,7 @@
 				18B9FAEB18B2F7AF00668660 /* MissionItemEditViewController.m in Sources */,
 				1845DA86197B8834008945F8 /* GCSActivityIndicatorView.m in Sources */,
 				1845DA4919778ED9008945F8 /* GCSAccessoryFirmwareInterface.m in Sources */,
+				181104A91A98282D00D1B58D /* GCSHeartbeat.m in Sources */,
 				186AFA3018F90CAD00541FD6 /* GCSSikAT.m in Sources */,
 				01CEC56C19D9F8BD00320A34 /* GCDAsyncSocket.m in Sources */,
 				18B9FAEC18B2F7AF00668660 /* MissionItemTableViewController.m in Sources */,
@@ -2558,6 +2573,7 @@
 				CA0E551B19F7C27A00B11F12 /* GCSMapViewController+DataRate.m in Sources */,
 				CA0C44DC19230F570099B718 /* SiKFirmwareUploader.m in Sources */,
 				CA0B69B7189B787E0014C1E4 /* GCSSidebarController.m in Sources */,
+				181104A81A98282D00D1B58D /* GCSHeartbeat.m in Sources */,
 				CA094F2C18D534E100AC6AE4 /* WaypointAnnotationView.m in Sources */,
 				18A777F217CE9E910014451B /* FileUtils.m in Sources */,
 				CA92514616F9761A0008E92F /* WaypointMapBaseController.m in Sources */,

--- a/iGCS.xcodeproj/project.pbxproj
+++ b/iGCS.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		18069FD81836F7C70068E7A5 /* RNBluetoothInterface.m in Sources */ = {isa = PBXBuildFile; fileRef = 18069FBF1836F7C70068E7A5 /* RNBluetoothInterface.m */; };
 		181104A81A98282D00D1B58D /* GCSHeartbeat.m in Sources */ = {isa = PBXBuildFile; fileRef = 181104A71A98282D00D1B58D /* GCSHeartbeat.m */; };
 		181104A91A98282D00D1B58D /* GCSHeartbeat.m in Sources */ = {isa = PBXBuildFile; fileRef = 181104A71A98282D00D1B58D /* GCSHeartbeat.m */; };
+		181104BC1A99A08700D1B58D /* GCSHeartbeatManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 181104BA1A99A08700D1B58D /* GCSHeartbeatManager.m */; };
+		181104BD1A99A08700D1B58D /* GCSHeartbeatManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 181104BA1A99A08700D1B58D /* GCSHeartbeatManager.m */; };
 		1830D07217D1651400F77F7E /* DateTimeUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 1830D07117D1651400F77F7E /* DateTimeUtils.m */; };
 		1842F8CA1892D2F80050F680 /* Icon-29.png in Resources */ = {isa = PBXBuildFile; fileRef = 1842F8C41892D2F80050F680 /* Icon-29.png */; };
 		1842F8CC1892D2F80050F680 /* Icon-40.png in Resources */ = {isa = PBXBuildFile; fileRef = 1842F8C51892D2F80050F680 /* Icon-40.png */; };
@@ -474,6 +476,10 @@
 		18069FBF1836F7C70068E7A5 /* RNBluetoothInterface.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBluetoothInterface.m; sourceTree = "<group>"; };
 		181104A61A98282D00D1B58D /* GCSHeartbeat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCSHeartbeat.h; sourceTree = "<group>"; };
 		181104A71A98282D00D1B58D /* GCSHeartbeat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCSHeartbeat.m; sourceTree = "<group>"; };
+		181104AC1A998E9000D1B58D /* GCSTelemetry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCSTelemetry.h; sourceTree = "<group>"; };
+		181104B91A99A08700D1B58D /* GCSHeartbeatManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCSHeartbeatManager.h; sourceTree = "<group>"; };
+		181104BA1A99A08700D1B58D /* GCSHeartbeatManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCSHeartbeatManager.m; sourceTree = "<group>"; };
+		181104BB1A99A08700D1B58D /* TelemetryManagers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TelemetryManagers.h; sourceTree = "<group>"; };
 		1830D07017D1651400F77F7E /* DateTimeUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DateTimeUtils.h; sourceTree = "<group>"; };
 		1830D07117D1651400F77F7E /* DateTimeUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DateTimeUtils.m; sourceTree = "<group>"; };
 		1842F8C41892D2F80050F680 /* Icon-29.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Icon-29.png"; sourceTree = "<group>"; };
@@ -1195,8 +1201,19 @@
 		181104A51A98282D00D1B58D /* Telemetry */ = {
 			isa = PBXGroup;
 			children = (
+				181104AC1A998E9000D1B58D /* GCSTelemetry.h */,
 				181104A61A98282D00D1B58D /* GCSHeartbeat.h */,
 				181104A71A98282D00D1B58D /* GCSHeartbeat.m */,
+			);
+			path = Telemetry;
+			sourceTree = "<group>";
+		};
+		181104B81A99A08700D1B58D /* Telemetry */ = {
+			isa = PBXGroup;
+			children = (
+				181104BB1A99A08700D1B58D /* TelemetryManagers.h */,
+				181104B91A99A08700D1B58D /* GCSHeartbeatManager.h */,
+				181104BA1A99A08700D1B58D /* GCSHeartbeatManager.m */,
 			);
 			path = Telemetry;
 			sourceTree = "<group>";
@@ -1563,6 +1580,7 @@
 		18C91D201A71F71C009400C3 /* Managers */ = {
 			isa = PBXGroup;
 			children = (
+				181104B81A99A08700D1B58D /* Telemetry */,
 				18820E801A64AD0C006855E9 /* GCSSpeechManager.h */,
 				18820E811A64AD0C006855E9 /* GCSSpeechManager.m */,
 				18C91D231A71F739009400C3 /* GCSDataManager.h */,
@@ -2378,6 +2396,7 @@
 				18B7F2C61958953B00D2406A /* ALView+PureLayout.m in Sources */,
 				CA0E11911A0A1B1D00E0E622 /* MissionItemCell.m in Sources */,
 				CA0D06E71975F4C6002458F5 /* GCSTelemetryLossOverlayView.m in Sources */,
+				181104BD1A99A08700D1B58D /* GCSHeartbeatManager.m in Sources */,
 				18B9FACA18B2F7AF00668660 /* GuidedPointAnnotation.m in Sources */,
 				18B9FACB18B2F7AF00668660 /* GCSThemeManager.m in Sources */,
 				01CEC5D419D9FA3800320A34 /* BRRequest.m in Sources */,
@@ -2519,6 +2538,7 @@
 				496E629316DAFB8B00E52E4A /* MainViewController.m in Sources */,
 				496E629516DAFB8B00E52E4A /* WaypointsViewController.m in Sources */,
 				1830D07217D1651400F77F7E /* DateTimeUtils.m in Sources */,
+				181104BC1A99A08700D1B58D /* GCSHeartbeatManager.m in Sources */,
 				18069FD41836F7C70068E7A5 /* iGCSRadioConfig.m in Sources */,
 				496E629716DAFB8B00E52E4A /* ArtificialHorizonView.m in Sources */,
 				496E629916DAFB8B00E52E4A /* CompassView.m in Sources */,

--- a/iGCS.xcodeproj/xcshareddata/xcschemes/iGCS.xcscheme
+++ b/iGCS.xcodeproj/xcshareddata/xcschemes/iGCS.xcscheme
@@ -68,7 +68,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">

--- a/iGCS.xcodeproj/xcshareddata/xcschemes/iGCS.xcscheme
+++ b/iGCS.xcodeproj/xcshareddata/xcschemes/iGCS.xcscheme
@@ -68,7 +68,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">

--- a/iGCS/AppDelegate.m
+++ b/iGCS/AppDelegate.m
@@ -73,6 +73,8 @@ static AppDelegate *shared;
      Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
      Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
      */
+
+    [[CommController sharedInstance] closeAllInterfaces];
     if (alertView.visible) {
 		[alertView dismissWithClickedButtonIndex:0 animated:YES];
 	}
@@ -85,7 +87,7 @@ static AppDelegate *shared;
      Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
      If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
      */
-    
+
 	[updateTimer invalidate]; // shutdown the timer;
     
 	NSLog(@"Entering Background");

--- a/iGCS/Comm/MavLink/Utility/MavLinkUtility.h
+++ b/iGCS/Comm/MavLink/Utility/MavLinkUtility.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "GCSHeartbeat.h"
 #import "MavLinkTools.h"
 #import "MissionItemField.h"
 
@@ -14,7 +15,7 @@
 
 + (NSString*) mavModeEnumToString:(enum MAV_MODE)mode;
 + (NSString*) mavStateEnumToString:(enum MAV_STATE)state;
-+ (NSString*) mavCustomModeToString:(mavlink_heartbeat_t) heartbeat;
++ (NSString *) mavCustomModeToString:(GCSHeartbeat *) heartbeat;
 
 + (NSArray*) supportedMissionItemTypes;
 + (NSArray*) missionItemMetadataWith:(uint16_t)command;

--- a/iGCS/Comm/MavLink/Utility/MavLinkUtility.m
+++ b/iGCS/Comm/MavLink/Utility/MavLinkUtility.m
@@ -8,6 +8,7 @@
 
 #import "MavLinkUtility.h"
 #import "GCSCraftModes.h"
+#import "GCSHeartbeat.h"
 
 @implementation MavLinkUtility
 
@@ -185,21 +186,21 @@ NSDictionary *_ardupilotModes;
     return [NSString stringWithFormat:@"MAV_STATE (%d)", state];
 }
 
-+ (NSString *) mavCustomModeToString:(mavlink_heartbeat_t) heartbeat {
++ (NSString *) mavCustomModeToString:(GCSHeartbeat *) heartbeat {
     
     NSString *modeName;
     
     // APMPlane Auto Pilot Modes
     if (heartbeat.autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        modeName = _ardupilotModes[@(heartbeat.type)][@(heartbeat.custom_mode)];
+        modeName = _ardupilotModes[@(heartbeat.mavType)][@(heartbeat.customMode)];
     }
     //The ARDrone shows up as a MAV_AUTOPILOT_GENERIC
     //It also uses the system_status field for the moding instead of the custom_mode field
-    if (heartbeat.autopilot == MAV_AUTOPILOT_GENERIC && heartbeat.type == MAV_TYPE_QUADROTOR) {
-        modeName = [MavLinkUtility mavStateEnumToString:heartbeat.system_status];
+    if (heartbeat.autopilot == MAV_AUTOPILOT_GENERIC && heartbeat.mavType == MAV_TYPE_QUADROTOR) {
+        modeName = [MavLinkUtility mavStateEnumToString:heartbeat.systemStatus];
     }
     
-    return modeName ?: [NSString stringWithFormat:@"CUSTOM_MODE (%d)", heartbeat.custom_mode];
+    return modeName ?: [NSString stringWithFormat:@"CUSTOM_MODE (%d)", heartbeat.customMode];
 }
 
 + (NSArray *) supportedMissionItemTypes {

--- a/iGCS/Managers/Telemetry/GCSHeartbeatManager.h
+++ b/iGCS/Managers/Telemetry/GCSHeartbeatManager.h
@@ -1,0 +1,16 @@
+//
+//  GCSHeartbeatManager.h
+//  iGCS
+//
+//  Created by Andrew Brown on 2/21/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface GCSHeartbeatManager : NSObject
+- (void) rescheduleLossCheck;
+@end
+
+extern NSString * const GCSHeartbeatManagerHeartbeatWasLost;
+extern NSString * const GCSHeartbeatManagerHeartbeatDidArrive;

--- a/iGCS/Managers/Telemetry/GCSHeartbeatManager.m
+++ b/iGCS/Managers/Telemetry/GCSHeartbeatManager.m
@@ -1,0 +1,40 @@
+//
+//  GCSHeartbeatManager.m
+//  iGCS
+//
+//  Created by Andrew Brown on 2/21/15.
+//
+//
+
+#import "GCSHeartbeatManager.h"
+
+NSString * const GCSHeartbeatManagerHeartbeatWasLost = @"GCSHeartbeatManagerHeartbeatWasLost";
+NSString * const GCSHeartbeatManagerHeartbeatDidArrive = @"GCSHeartbeatManagerHeartbeatDidArrive";
+
+@implementation GCSHeartbeatManager
+
+static const double HEARTBEAT_LOSS_WAIT_TIME = 3.0;
+
+- (void)postHeartbeatWasLostNotification {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter]postNotificationName:GCSHeartbeatManagerHeartbeatWasLost
+                                                           object:nil];
+    });
+}
+
+- (void)postHeartbeatDidArriveNotification {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter]postNotificationName:GCSHeartbeatManagerHeartbeatDidArrive
+                                                           object:nil];
+    });
+}
+
+#pragma mark - Public API
+- (void) rescheduleLossCheck {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(postHeartbeatWasLostNotification) object:nil];
+    [self postHeartbeatDidArriveNotification];
+    [self performSelector:@selector(postHeartbeatWasLostNotification) withObject:nil afterDelay:HEARTBEAT_LOSS_WAIT_TIME];
+}
+
+@end
+

--- a/iGCS/Managers/Telemetry/TelemetryManagers.h
+++ b/iGCS/Managers/Telemetry/TelemetryManagers.h
@@ -1,0 +1,17 @@
+//
+//  TelemetryManagers.h
+//  iGCS
+//
+//  Created by Andrew Brown on 2/21/15.
+//
+//
+
+#ifndef iGCS_TelemetryManagers_h
+#define iGCS_TelemetryManagers_h
+
+// import models and model
+// generators with public interfaces
+#import "GCSTelemetry.h"
+#import "GCSHeartbeatManager.h"
+
+#endif

--- a/iGCS/Models/Craft/GCSCraftArduCopter.h
+++ b/iGCS/Models/Craft/GCSCraftArduCopter.h
@@ -8,7 +8,8 @@
 
 #import <Foundation/Foundation.h>
 #import "GCSCraftModel.h"
+#import "GCSHeartbeat.h"
 
 @interface GCSCraftArduCopter : NSObject <GCSCraftModel>
-@property (nonatomic, assign) mavlink_heartbeat_t heartbeat;
+@property (nonatomic, strong) GCSHeartbeat *heartbeat;
 @end

--- a/iGCS/Models/Craft/GCSCraftArduCopter.m
+++ b/iGCS/Models/Craft/GCSCraftArduCopter.m
@@ -13,12 +13,6 @@
 #import "GCSCraftMixins.h"
 #import "Mixin.h"
 
-
-@interface GCSCraftArduCopter ()
-@property (nonatomic, strong) NSNotificationCenter *notificationCenter;
-@property (nonatomic, strong) NSOperationQueue *craftQueue;
-@end
-
 @implementation GCSCraftArduCopter
 
 @synthesize craftType  = _craftType;
@@ -26,6 +20,8 @@
 @synthesize guidedMode = _guidedMode;
 @synthesize setModeBeforeGuidedItems  = _setModeBeforeGuidedItems;
 @synthesize icon = _icon;
+@synthesize notificationCenter = _notificationCenter;
+@synthesize craftQueue = _craftQueue;
 
 - (id<GCSCraftModel>) init:(GCSHeartbeat*)heartbeat {
     self = [super init];
@@ -38,6 +34,7 @@
         _setModeBeforeGuidedItems = YES; // For 3.2+
         _icon = [UIImage imageNamed:@"quad-icon-128.png"];
         _notificationCenter = [NSNotificationCenter defaultCenter];
+        _craftQueue = [[NSOperationQueue alloc] init];
 
         // set heartbeat to nil when app goes into background so all
         // events fire again on app launch and telemetry reconnect
@@ -59,10 +56,6 @@
     }
 
     return self;
-}
-
-- (void)dealloc {
-    [self.notificationCenter removeObserver:self];
 }
 
 + (void)load {

--- a/iGCS/Models/Craft/GCSCraftArduCopter.m
+++ b/iGCS/Models/Craft/GCSCraftArduCopter.m
@@ -20,7 +20,7 @@
 @synthesize setModeBeforeGuidedItems  = _setModeBeforeGuidedItems;
 @synthesize icon = _icon;
 
-- (id<GCSCraftModel>) init:(mavlink_heartbeat_t)heartbeat {
+- (id<GCSCraftModel>) init:(GCSHeartbeat*)heartbeat {
     self = [super init];
     if (self) {
         _heartbeat = heartbeat;
@@ -30,9 +30,18 @@
         _guidedMode  = APMCopterGuided;
         _setModeBeforeGuidedItems = YES; // For 3.2+
         _icon = [UIImage imageNamed:@"quad-icon-128.png"];
+
+        // set heartbeat to nil when app goes into background so all
+        // events fire again on app launch and telemetry reconnect
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(clearHearbeat)
+                                                     name:UIApplicationDidEnterBackgroundNotification object:nil];
     }
 
     return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 + (void)load {
@@ -42,12 +51,17 @@
     });
 }
 
+- (void)clearHearbeat {
+    self.heartbeat = nil;
+}
+
+#pragma mark -  External API
 - (BOOL) isInAutoMode {
-    return self.heartbeat.custom_mode == APMCopterAuto;
+    return self.heartbeat.customMode == APMCopterAuto;
 }
 
 - (BOOL) isInGuidedMode {
-    return self.heartbeat.custom_mode == APMCopterGuided;
+    return self.heartbeat.customMode == APMCopterGuided;
 }
 
 @end

--- a/iGCS/Models/Craft/GCSCraftArduPlane.h
+++ b/iGCS/Models/Craft/GCSCraftArduPlane.h
@@ -10,5 +10,5 @@
 #import "GCSCraftModel.h"
 
 @interface GCSCraftArduPlane : NSObject <GCSCraftModel>
-@property (nonatomic, assign) mavlink_heartbeat_t heartbeat;
+@property (nonatomic, strong) GCSHeartbeat* heartbeat;
 @end

--- a/iGCS/Models/Craft/GCSCraftArduPlane.m
+++ b/iGCS/Models/Craft/GCSCraftArduPlane.m
@@ -13,11 +13,6 @@
 #import "GCSCraftMixins.h"
 #import "Mixin.h"
 
-@interface GCSCraftArduPlane ()
-@property (nonatomic, strong) NSNotificationCenter *notificationCenter;
-@property (nonatomic, strong) NSOperationQueue *craftQueue;
-@end
-
 @implementation GCSCraftArduPlane
 
 @synthesize craftType  = _craftType;
@@ -25,6 +20,8 @@
 @synthesize guidedMode = _guidedMode;
 @synthesize setModeBeforeGuidedItems  = _setModeBeforeGuidedItems;
 @synthesize icon = _icon;
+@synthesize notificationCenter = _notificationCenter;
+@synthesize craftQueue = _craftQueue;
 
 - (id<GCSCraftModel>) init:(GCSHeartbeat *)heartbeat {
     self = [super init];
@@ -58,10 +55,6 @@
     }
 
     return self;
-}
-
-- (void)dealloc {
-    [self.notificationCenter removeObserver:self];
 }
 
 + (void)load {

--- a/iGCS/Models/Craft/GCSCraftArduPlane.m
+++ b/iGCS/Models/Craft/GCSCraftArduPlane.m
@@ -20,7 +20,7 @@
 @synthesize setModeBeforeGuidedItems  = _setModeBeforeGuidedItems;
 @synthesize icon = _icon;
 
-- (id<GCSCraftModel>) init:(mavlink_heartbeat_t)heartbeat {
+- (id<GCSCraftModel>) init:(GCSHeartbeat *)heartbeat {
     self = [super init];
     if (self) {
         _heartbeat = heartbeat;
@@ -30,9 +30,19 @@
         _guidedMode  = APMPlaneGuided;
         _setModeBeforeGuidedItems = NO;
         _icon = [UIImage imageNamed:@"plane-icon-128.png"];
+
+        // set heartbeat to nil when app goes into background so all
+        // events fire again on app launch and telemetry reconnect
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(clearHearbeat)
+                                                     name:UIApplicationDidEnterBackgroundNotification object:nil];
+
     }
 
     return self;
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 + (void)load {
@@ -42,12 +52,18 @@
     });
 }
 
+- (void)clearHearbeat {
+    self.heartbeat = nil;
+}
+
+#pragma mark -  External API
 - (BOOL) isInAutoMode {
-    return self.heartbeat.custom_mode == APMPlaneAuto;
+    return self.heartbeat.customMode == APMPlaneAuto;
 }
 
 - (BOOL) isInGuidedMode {
-    return self.heartbeat.custom_mode == APMPlaneGuided;
+    return self.heartbeat.customMode == APMPlaneGuided;
 }
+
 
 @end

--- a/iGCS/Models/Craft/GCSCraftMixins.h
+++ b/iGCS/Models/Craft/GCSCraftMixins.h
@@ -8,8 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "GCSCraft.h"
+#import "GCSHeartbeat.h"
 
 @interface GCSCraftMixins : NSObject
--(void)updateWithHeartbeat:(mavlink_heartbeat_t) heartbeat;
+-(void)updateWithHeartbeat:(GCSHeartbeat *) heartbeat;
 - (NSString *) currentModeName;
 @end

--- a/iGCS/Models/Craft/GCSCraftMixins.m
+++ b/iGCS/Models/Craft/GCSCraftMixins.m
@@ -12,12 +12,12 @@
 
 @implementation GCSCraftMixins
 
--(void)updateWithHeartbeat:(mavlink_heartbeat_t) heartbeat {
+-(void)updateWithHeartbeat:(GCSHeartbeat *)heartbeat {
     // this is needed because we expect the model state to have
     // already changed by the time NSNotifications are
     // dispatch so the model properties must be updated
     // before the notifications are sent out.
-    mavlink_heartbeat_t lastHeartbeat = [(id)self heartbeat];
+    GCSHeartbeat *lastHeartbeat = [(id)self heartbeat];
     [(id)self setHeartbeat:heartbeat];
 
     // Order of notifications matter to GCSSpeechManager
@@ -30,12 +30,12 @@
 
 }
 
-- (NSString *) currentModeName {
+- (NSString *)currentModeName {
     return [MavLinkUtility mavCustomModeToString:[(id)self heartbeat]];
 }
 
-- (BOOL) isArmed {
-    return ([(id)self heartbeat].base_mode & MAV_MODE_FLAG_SAFETY_ARMED);
+- (BOOL)isArmed {
+    return ([(id)self heartbeat].isArmed);
 }
 
 @end

--- a/iGCS/Models/Craft/GCSCraftMixins.m
+++ b/iGCS/Models/Craft/GCSCraftMixins.m
@@ -38,4 +38,9 @@
     return ([(id)self heartbeat].isArmed);
 }
 
+// class lifecycle
+- (void)dealloc {
+    [[(id)self notificationCenter] removeObserver:self];
+}
+
 @end

--- a/iGCS/Models/Craft/GCSCraftModel.h
+++ b/iGCS/Models/Craft/GCSCraftModel.h
@@ -28,6 +28,8 @@
 // Representation
 @property (nonatomic, readonly) UIImage* icon;
 
+@property (nonatomic, strong) NSNotificationCenter *notificationCenter;
+@property (nonatomic, strong) NSOperationQueue *craftQueue;
 // These methods are optional so they can be mixed in
 // at runtime
 @optional;

--- a/iGCS/Models/Craft/GCSCraftModel.h
+++ b/iGCS/Models/Craft/GCSCraftModel.h
@@ -7,12 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "mavlink.h"
 #import "GCSCraftModes.h"
+#import "GCSHeartbeat.h"
 
 @protocol GCSCraftModel <NSObject>
 @required;
-- (id<GCSCraftModel>) init:(mavlink_heartbeat_t)heartbeat;
+- (id<GCSCraftModel>) init:(GCSHeartbeat *)heartbeat;
 
 @property (nonatomic, readonly) GCSCraftType craftType;
 
@@ -32,7 +32,7 @@
 // at runtime
 @optional;
 @property (nonatomic, readonly) NSString *currentModeName;
-- (void) updateWithHeartbeat:(mavlink_heartbeat_t)heartbeat;
+- (void) updateWithHeartbeat:(GCSHeartbeat *)heartbeat;
 - (BOOL) isArmed;
 
 

--- a/iGCS/Models/Craft/GCSCraftModelGenerator.h
+++ b/iGCS/Models/Craft/GCSCraftModelGenerator.h
@@ -8,8 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "GCSCraftModel.h"
+#import "GCSHeartbeat.h"
 
 @interface GCSCraftModelGenerator : NSObject
 + (id<GCSCraftModel>) createInitialModel;
-+ (id<GCSCraftModel>) updateOrReplaceModel:(id<GCSCraftModel>)model withCurrent:(mavlink_heartbeat_t)heartbeat;
++ (id<GCSCraftModel>) updateOrReplaceModel:(id<GCSCraftModel>)model withCurrent:(GCSHeartbeat *)heartbeat;
 @end

--- a/iGCS/Models/Craft/GCSCraftModelGenerator.m
+++ b/iGCS/Models/Craft/GCSCraftModelGenerator.m
@@ -12,8 +12,8 @@
 
 @implementation GCSCraftModelGenerator
 
-+ (GCSCraftType) craftTypeFromHeartbeat:(mavlink_heartbeat_t)heartbeat {
-    switch (heartbeat.type) {
++ (GCSCraftType) craftTypeFromHeartbeat:(GCSHeartbeat*)heartbeat {
+    switch (heartbeat.mavType) {
         case MAV_TYPE_TRICOPTER:
         case MAV_TYPE_QUADROTOR:
         case MAV_TYPE_HEXAROTOR:
@@ -33,15 +33,11 @@
 #pragma mark External API
 
 + (id<GCSCraftModel>) createInitialModel {
-    mavlink_heartbeat_t heartbeat;
-    // need base mode to be zeroed so initial status events are sent out
-    heartbeat.base_mode = 0;
-    heartbeat.type = MAV_TYPE_QUADROTOR;
-    return [[GCSCraftArduCopter alloc] init:heartbeat];
+    return [[GCSCraftArduCopter alloc] init:nil];
 }
 
 + (id<GCSCraftModel>) updateOrReplaceModel:(id<GCSCraftModel>)model
-                               withCurrent:(mavlink_heartbeat_t)heartbeat {
+                               withCurrent:(GCSHeartbeat *)heartbeat {
     GCSCraftType craftType = [GCSCraftModelGenerator craftTypeFromHeartbeat:heartbeat];
     
     // Mutate the existing model

--- a/iGCS/Models/Craft/GCSCraftNotifications.h
+++ b/iGCS/Models/Craft/GCSCraftNotifications.h
@@ -11,11 +11,11 @@
 
 @interface GCSCraftNotifications : NSObject
 
-+ (void)didNavModeChangeFromLastHeartbeat:(GCSHeartbeat *) lastHeartbeat
-                      andNewHeartbeat:(GCSHeartbeat *) newHeartbeat;
++ (void)didNavModeChangeFromLastHeartbeat:(GCSHeartbeat *)lastHeartbeat
+                          andNewHeartbeat:(GCSHeartbeat *)newHeartbeat;
 
-+ (void)didArmedStatusChangeFromLastHeartbeat:(GCSHeartbeat*) lastHeartbeat
-                              andNewHeartbeat:(GCSHeartbeat*) newHeartbeat;
++ (void)didArmedStatusChangeFromLastHeartbeat:(GCSHeartbeat*)lastHeartbeat
+                              andNewHeartbeat:(GCSHeartbeat*)newHeartbeat;
 
 @end
 

--- a/iGCS/Models/Craft/GCSCraftNotifications.h
+++ b/iGCS/Models/Craft/GCSCraftNotifications.h
@@ -7,15 +7,15 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "mavlink.h"
+#import "GCSHeartbeat.h"
 
 @interface GCSCraftNotifications : NSObject
 
-+ (void)didNavModeChangeFromLastHeartbeat:(mavlink_heartbeat_t) lastHeartbeat
-                      andNewHeartbeat:(mavlink_heartbeat_t) newHeartbeat;
++ (void)didNavModeChangeFromLastHeartbeat:(GCSHeartbeat *) lastHeartbeat
+                      andNewHeartbeat:(GCSHeartbeat *) newHeartbeat;
 
-+ (void)didArmedStatusChangeFromLastHeartbeat:(mavlink_heartbeat_t) lastHeartbeat
-                              andNewHeartbeat:(mavlink_heartbeat_t) newHeartbeat;
++ (void)didArmedStatusChangeFromLastHeartbeat:(GCSHeartbeat*) lastHeartbeat
+                              andNewHeartbeat:(GCSHeartbeat*) newHeartbeat;
 
 @end
 

--- a/iGCS/Models/Craft/GCSCraftNotifications.m
+++ b/iGCS/Models/Craft/GCSCraftNotifications.m
@@ -14,9 +14,8 @@ NSString * const GCSCraftNotificationsCraftArmedStatusDidChange = @"GCSCraftNoti
 
 @implementation GCSCraftNotifications
 
-+ (void)didNavModeChangeFromLastHeartbeat:(GCSHeartbeat *) lastHeartbeat
-                      andNewHeartbeat:(GCSHeartbeat *) newHeartbeat {
-
++ (void)didNavModeChangeFromLastHeartbeat:(GCSHeartbeat *)lastHeartbeat
+                          andNewHeartbeat:(GCSHeartbeat *)newHeartbeat {
 
     if (lastHeartbeat && lastHeartbeat.customMode == newHeartbeat.customMode) return;
 
@@ -26,12 +25,10 @@ NSString * const GCSCraftNotificationsCraftArmedStatusDidChange = @"GCSCraftNoti
     });
 }
 
-+ (void)didArmedStatusChangeFromLastHeartbeat:(GCSHeartbeat *) lastHeartbeat
-                              andNewHeartbeat:(GCSHeartbeat *) newHeartbeat {
++ (void)didArmedStatusChangeFromLastHeartbeat:(GCSHeartbeat *)lastHeartbeat
+                              andNewHeartbeat:(GCSHeartbeat *)newHeartbeat {
 
-
-    // if lastHeartbeat is not nil AND the armings status has not changes return
-    if (lastHeartbeat && (lastHeartbeat.isArmed) == (newHeartbeat.isArmed)) {
+    if (lastHeartbeat && lastHeartbeat.isArmed == newHeartbeat.isArmed) {
         return;
     }
 

--- a/iGCS/Models/Craft/GCSCraftNotifications.m
+++ b/iGCS/Models/Craft/GCSCraftNotifications.m
@@ -14,10 +14,11 @@ NSString * const GCSCraftNotificationsCraftArmedStatusDidChange = @"GCSCraftNoti
 
 @implementation GCSCraftNotifications
 
-+ (void)didNavModeChangeFromLastHeartbeat:(mavlink_heartbeat_t) lastHeartbeat
-                      andNewHeartbeat:(mavlink_heartbeat_t) newHeartbeat {
++ (void)didNavModeChangeFromLastHeartbeat:(GCSHeartbeat *) lastHeartbeat
+                      andNewHeartbeat:(GCSHeartbeat *) newHeartbeat {
 
-    if (lastHeartbeat.custom_mode == newHeartbeat.custom_mode) return;
+
+    if (lastHeartbeat && lastHeartbeat.customMode == newHeartbeat.customMode) return;
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [[NSNotificationCenter defaultCenter]postNotificationName:GCSCraftNotificationsCraftCustomModeDidChange
@@ -25,11 +26,12 @@ NSString * const GCSCraftNotificationsCraftArmedStatusDidChange = @"GCSCraftNoti
     });
 }
 
-+ (void)didArmedStatusChangeFromLastHeartbeat:(mavlink_heartbeat_t) lastHeartbeat
-                              andNewHeartbeat:(mavlink_heartbeat_t) newHeartbeat {
++ (void)didArmedStatusChangeFromLastHeartbeat:(GCSHeartbeat *) lastHeartbeat
+                              andNewHeartbeat:(GCSHeartbeat *) newHeartbeat {
 
-    if (lastHeartbeat.base_mode != 0 &&
-        (lastHeartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED) == (newHeartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED)) {
+
+    // if lastHeartbeat is not nil AND the armings status has not changes return
+    if (lastHeartbeat && (lastHeartbeat.isArmed) == (newHeartbeat.isArmed)) {
         return;
     }
 

--- a/iGCS/Models/Telemetry/GCSHeartbeat.h
+++ b/iGCS/Models/Telemetry/GCSHeartbeat.h
@@ -1,0 +1,22 @@
+//
+//  GCSHeartbeatModel.h
+//  iGCS
+//
+//  Created by Andrew Brown on 2/20/15.
+//
+//
+
+#import <Foundation/Foundation.h>
+#import "mavlink.h"
+
+@interface GCSHeartbeat : NSObject
++(GCSHeartbeat *) heartbeatFromMavlinkHeartbeat:(mavlink_heartbeat_t)heartbeat;
+// basic pass through properties from backing struct
+@property (nonatomic, readonly) uint32_t customMode;
+@property (nonatomic, readonly) uint8_t mavType;
+@property (nonatomic, readonly) uint8_t autopilot;
+@property (nonatomic, readonly) uint8_t baseMode;
+@property (nonatomic, readonly) uint8_t systemStatus;
+@property (nonatomic, readonly) uint8_t telemetryVersion;
+@property (nonatomic, readonly) BOOL isArmed;
+@end

--- a/iGCS/Models/Telemetry/GCSHeartbeat.m
+++ b/iGCS/Models/Telemetry/GCSHeartbeat.m
@@ -16,8 +16,7 @@
 @implementation GCSHeartbeat
 
 + (GCSHeartbeat *)heartbeatFromMavlinkHeartbeat:(mavlink_heartbeat_t)heartbeat {
-    GCSHeartbeat *aHeartbeat = [[GCSHeartbeat alloc] initWithHeartbeat:heartbeat];
-    return aHeartbeat;
+    return [[GCSHeartbeat alloc] initWithHeartbeat:heartbeat];
 }
 
 - (instancetype)initWithHeartbeat:(mavlink_heartbeat_t) heartbeat {

--- a/iGCS/Models/Telemetry/GCSHeartbeat.m
+++ b/iGCS/Models/Telemetry/GCSHeartbeat.m
@@ -1,0 +1,61 @@
+//
+//  GCSHeartbeatModel.m
+//  iGCS
+//
+//  Created by Andrew Brown on 2/20/15.
+//
+//
+
+#import "GCSHeartbeat.h"
+
+@interface GCSHeartbeat ()
+@property (nonatomic, assign) mavlink_heartbeat_t heartbeat;
+- (instancetype)initWithHeartbeat:(mavlink_heartbeat_t) heartbeat;
+@end
+
+@implementation GCSHeartbeat
+
++ (GCSHeartbeat *)heartbeatFromMavlinkHeartbeat:(mavlink_heartbeat_t)heartbeat {
+    GCSHeartbeat *aHeartbeat = [[GCSHeartbeat alloc] initWithHeartbeat:heartbeat];
+    return aHeartbeat;
+}
+
+- (instancetype)initWithHeartbeat:(mavlink_heartbeat_t) heartbeat {
+    self = [super init];
+    if (self) {
+        _heartbeat = heartbeat;
+    }
+    return self;
+}
+
+#pragma mark - properties backed by MAVLink heartbeat struct
+- (uint32_t)customMode {
+    return self.heartbeat.custom_mode;
+}
+
+- (uint8_t)mavType {
+    return self.heartbeat.type;
+}
+
+- (uint8_t)autopilot {
+    return self.heartbeat.autopilot;
+}
+
+- (uint8_t)baseMode {
+    return self.heartbeat.base_mode;
+}
+
+- (uint8_t)systemStatus {
+    return self.heartbeat.base_mode;
+}
+
+- (uint8_t)telemetryVersion {
+    return self.heartbeat.mavlink_version;
+}
+
+#pragma mark - compound properties
+-(BOOL)isArmed {
+    return (self.heartbeat.base_mode & MAV_MODE_FLAG_SAFETY_ARMED);
+}
+
+@end

--- a/iGCS/Models/Telemetry/GCSTelemetry.h
+++ b/iGCS/Models/Telemetry/GCSTelemetry.h
@@ -1,0 +1,14 @@
+//
+//  GCSTelemetry.h
+//  iGCS
+//
+//  Created by Andrew Brown on 2/21/15.
+//
+//
+
+#ifndef iGCS_GCSTelemetry_h
+#define iGCS_GCSTelemetry_h
+
+#import "GCSHeartbeat.h"
+
+#endif

--- a/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
+++ b/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
@@ -78,6 +78,8 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
     self.showProposedFollowPos = NO;
     self.lastFollowMeUpdate = [NSDate date];
 
+
+    // configure NSNotifcation observer.
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(craftCustomModeDidChange)
                                                  name:GCSCraftNotificationsCraftCustomModeDidChange
@@ -86,6 +88,11 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(craftArmedStatusDidChange)
                                                  name:GCSCraftNotificationsCraftArmedStatusDidChange
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(resetTelemetryUserInterface)
+                                                 name:UIApplicationWillResignActiveNotification
                                                object:nil];
 }
 
@@ -174,7 +181,6 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
 
 #pragma mark - 
 #pragma mark Handle NSnotifications for UI updates
-
 - (void)craftArmedStatusDidChange {
     // Update armed status labels
     [self.armedLabel setText:([GCSDataManager sharedInstance].craft.isArmed) ? @"Armed" : @"Disarmed"];
@@ -183,6 +189,14 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
 
 - (void)craftCustomModeDidChange {
     [self.customModeLabel setText:[GCSDataManager sharedInstance].craft.currentModeName];
+}
+
+- (void)resetTelemetryUserInterface {
+    [self.armedLabel setText:@"-"];
+    [self.armedLabel setTextColor:[UIColor whiteColor]];
+
+    [self.customModeLabel setText:@"-"];
+    [self.customModeLabel setTextColor:[UIColor whiteColor]];
 }
 
 #pragma mark -

--- a/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
+++ b/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
@@ -47,8 +47,6 @@ enum {
     CONTROL_MODE_GUIDED   = 2
 };
 
-static const double HEARTBEAT_LOSS_WAIT_TIME = 3.0;
-
 static const double FOLLOW_ME_MIN_UPDATE_TIME   = 2.0;
 static const double FOLLOW_ME_REQUIRED_ACCURACY = 10.0;
 
@@ -209,7 +207,6 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
     [self.armedLabel setTextColor:[UIColor whiteColor]];
 
     [self.customModeLabel setText:@"-"];
-    [self.customModeLabel setTextColor:[UIColor whiteColor]];
 }
 
 -(void) showTelemetryLossOverlay {
@@ -391,12 +388,6 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
     CXAlertView *alertView = (CXAlertView*)(sender.view);
     [(UILabel*)[alertView contentView] setText:[GCSMapViewController formatGotoAlertMessage:self.gotoCoordinates
                                                                                     withAlt:self.gotoAltitude]];
-}
-
-- (void) rescheduleHeartbeatLossCheck {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self.telemetryLossView selector:@selector(show) object:nil];
-    [self.telemetryLossView hide];
-    [self.telemetryLossView performSelector:@selector(show) withObject:nil afterDelay:HEARTBEAT_LOSS_WAIT_TIME];
 }
 
 - (void) handlePacket:(mavlink_message_t*)msg {

--- a/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
+++ b/iGCS/UserInterface/ViewControllers/GCSMapViewController.m
@@ -19,6 +19,7 @@
 
 #import "CXAlertView.h"
 
+#import "GCSHeartbeat.h"
 #import "GCSSpeechManager.h"
 #import "GCSDataManager.h"
 
@@ -455,7 +456,7 @@ static const NSUInteger VEHICLE_ICON_SIZE = 64;
 
             // Mutate existing craft, or replace if required (e.g. type has changed)
             [GCSDataManager sharedInstance].craft = [GCSCraftModelGenerator updateOrReplaceModel:[GCSDataManager sharedInstance].craft
-                                                                                     withCurrent:heartbeat];
+                                                                                     withCurrent:[GCSHeartbeat heartbeatFromMavlinkHeartbeat:heartbeat]];
 
             // Update segmented control
             NSInteger idx = CONTROL_MODE_RC;

--- a/iGCS/UserInterface/ViewControllers/GCSSidebarController.m
+++ b/iGCS/UserInterface/ViewControllers/GCSSidebarController.m
@@ -58,9 +58,10 @@
         case MAVLINK_MSG_ID_HEARTBEAT: {
             mavlink_heartbeat_t heartbeat;
             mavlink_msg_heartbeat_decode(msg, &heartbeat);
-            [_mavBaseModeLabel   setText:[MavLinkUtility mavModeEnumToString:    heartbeat.base_mode]];
-            [_mavCustomModeLabel setText:[MavLinkUtility mavCustomModeToString:  heartbeat]];
-            [_mavStatusLabel     setText:[MavLinkUtility mavStateEnumToString:   heartbeat.system_status]];
+            GCSHeartbeat *aHeartbeat = [GCSHeartbeat heartbeatFromMavlinkHeartbeat:heartbeat];
+            [_mavBaseModeLabel   setText:[MavLinkUtility mavModeEnumToString:heartbeat.base_mode]];
+            [_mavCustomModeLabel setText:[MavLinkUtility mavCustomModeToString:aHeartbeat]];
+            [_mavStatusLabel     setText:[MavLinkUtility mavStateEnumToString:heartbeat.system_status]];
         }
             break;
             


### PR DESCRIPTION
- Fix logic error with arming status voice/ui update
- Nil out craft heartbeat object so labels are sure to be
  populated and status spoken when app enters the
  foreground again.
- Handle case where telemetry is lost; nil out craft heartbeat object etc.